### PR TITLE
v0.2.71: fix Mamba-2 in_proj weight loading for vLLM 0.16.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qwerky-vllm-models"
-version = "0.2.70"
+version = "0.2.71"
 description = "vLLM plugin for Qwerky AI MambaInLlama hybrid models"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/qwerky_vllm_models/__init__.py
+++ b/qwerky_vllm_models/__init__.py
@@ -23,7 +23,7 @@ Usage:
     vllm serve QwerkyAI/Qwerky-Llama3.1-Mamba-8B-Llama3.3-70B-base-distill
 """
 
-__version__ = "0.2.70"
+__version__ = "0.2.71"
 
 # Track if we've already registered with Transformers
 _transformers_registered = False

--- a/qwerky_vllm_models/modeling/model.py
+++ b/qwerky_vllm_models/modeling/model.py
@@ -569,7 +569,7 @@ class MambaInLlamaMambaForCausalLMNative(*_NativeBaseClasses):
                     loaded_params.add(new_name)
                 continue
 
-            # === Mamba in_proj: split fused weight into 5 shards ===
+            # === Mamba in_proj: split fused weight into shards ===
             if ".mamba.in_proj.weight" in name:
                 param_name = name
                 if param_name not in params_dict:
@@ -578,9 +578,14 @@ class MambaInLlamaMambaForCausalLMNative(*_NativeBaseClasses):
                     param = params_dict[param_name]
                     weight_loader = getattr(param, "weight_loader",
                                             default_weight_loader)
-                    shards = torch.split(loaded_weight, mamba_in_proj_sizes, dim=0)
-                    for shard_id, shard_weight in enumerate(shards):
-                        weight_loader(param, shard_weight, shard_id)
+                    if is_mamba2:
+                        # MambaMixer2's weight_loader handles sharding internally
+                        weight_loader(param, loaded_weight)
+                    else:
+                        # Mamba 1: manually split and load via MergedColumnParallelLinear
+                        shards = torch.split(loaded_weight, mamba_in_proj_sizes, dim=0)
+                        for shard_id, shard_weight in enumerate(shards):
+                            weight_loader(param, shard_weight, shard_id)
                     loaded_params.add(param_name)
                 continue
 


### PR DESCRIPTION
## Summary
- Fix MambaMixer2 in_proj weight loading — pass full fused weight directly (2 args) instead of splitting into shards (3 args)
- MambaMixer2 handles sharding internally, unlike MergedColumnParallelLinear
- Mamba-1 path unchanged
- Version bump 0.2.70 → 0.2.71

## Tested
- Verified on vLLM 0.16.0 with HybridMamba2 model
- Coherent output, CUDA graphs, 5 concurrent requests
- 114 benchmark experiments ran on this exact code (H100 shootout)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.2.71

* **Refactor**
  * Optimized weight loading mechanism for model initialization across architecture variants to improve performance and efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->